### PR TITLE
Fix issue in check_schema

### DIFF
--- a/gen-pack
+++ b/gen-pack
@@ -65,31 +65,27 @@ function apply_patches {
 }
 
 function check_schema {
-  if [ -n ${UTILITY_XMLLINT+x} ]; then
-    echo "Running schema check for $1"
-    local SCHEMA=$(realpath -m "${CMSIS_TOOLSDIR}/../PACK.xsd")
-    if [ ! -f "$SCHEMA" ]; then
-      echo "Fetching schema file..."
-      local SCHEMAURL=$(grep -Pio "xs:noNamespaceSchemaLocation=\"\K[^\"]+" "$1")
-      local SCHEMA="${TEMP:-/tmp}/PACK.xsd"
-      echo "\"${UTILITY_CURL}\" -sL $SCHEMAURL --output \"${SCHEMA}\""
-      "${UTILITY_CURL}" -sL $SCHEMAURL --output "${SCHEMA}"
-      local errorlevel=$?
-      if [ $errorlevel -ne 0 ]; then
-        echo "Failed downloading schema from '$SCHEMAURL'. Skipping schema check." >&2
-        return 1
-      fi
-    fi
-    echo "\"${UTILITY_XMLLINT}\" --noout --schema \"${SCHEMA}\" \"$1\""
-    "${UTILITY_XMLLINT}" --noout --schema "${SCHEMA}" "$1"
+  echo "Running schema check for $1"
+  local SCHEMA=$(realpath -m "${CMSIS_TOOLSDIR}/../PACK.xsd")
+  if [ ! -f "$SCHEMA" ]; then
+    echo "Fetching schema file..."
+    local SCHEMAURL=$(grep -Pio "xs:noNamespaceSchemaLocation=\"\K[^\"]+" "$1")
+    local SCHEMA="${TEMP:-/tmp}/PACK.xsd"
+    echo "\"${UTILITY_CURL}\" -sL $SCHEMAURL --output \"${SCHEMA}\""
+    "${UTILITY_CURL}" -sL $SCHEMAURL --output "${SCHEMA}"
     local errorlevel=$?
     if [ $errorlevel -ne 0 ]; then
-      echo "build aborted: Schema check of $1 against ${SCHEMA} failed!" >&2
-      echo " " >&2
+      echo "Failed downloading schema from '$SCHEMAURL'. Skipping schema check." >&2
       exit 1
     fi
-  else
-    echo "Use MDK PackInstaller to run schema validation for $1"
+  fi
+  echo "\"${UTILITY_XMLLINT}\" --noout --schema \"${SCHEMA}\" \"$1\""
+  "${UTILITY_XMLLINT}" --noout --schema "${SCHEMA}" "$1"
+  local errorlevel=$?
+  if [ $errorlevel -ne 0 ]; then
+    echo "build aborted: Schema check of $1 against ${SCHEMA} failed!" >&2
+    echo " " >&2
+    exit 1
   fi
 }
 

--- a/gen-pack
+++ b/gen-pack
@@ -66,7 +66,7 @@ function apply_patches {
 
 function check_schema {
   if [ -n ${UTILITY_XMLLINT+x} ]; then
-    echo "Running schema check for ${PACK_VENDOR}.${PACK_NAME}.pdsc"
+    echo "Running schema check for $1"
     local SCHEMA=$(realpath -m "${CMSIS_TOOLSDIR}/../PACK.xsd")
     if [ ! -f "$SCHEMA" ]; then
       echo "Fetching schema file..."
@@ -74,17 +74,22 @@ function check_schema {
       local SCHEMA="${TEMP:-/tmp}/PACK.xsd"
       echo "\"${UTILITY_CURL}\" -sL $SCHEMAURL --output \"${SCHEMA}\""
       "${UTILITY_CURL}" -sL $SCHEMAURL --output "${SCHEMA}"
+      local errorlevel=$?
+      if [ $errorlevel -ne 0 ]; then
+        echo "Failed downloading schema from '$SCHEMAURL'. Skipping schema check." >&2
+        return 1
+      fi
     fi
     echo "\"${UTILITY_XMLLINT}\" --noout --schema \"${SCHEMA}\" \"$1\""
     "${UTILITY_XMLLINT}" --noout --schema "${SCHEMA}" "$1"
     local errorlevel=$?
     if [ $errorlevel -ne 0 ]; then
-      echo "build aborted: Schema check of $PACK_VENDOR.$PACK_NAME.pdsc against PACK.xsd failed"
-      echo " "
+      echo "build aborted: Schema check of $1 against ${SCHEMA} failed!" >&2
+      echo " " >&2
       exit 1
     fi
   else
-    echo "Use MDK PackInstaller to run schema validation for $PACK_VENDOR.$PACK_NAME.pdsc"
+    echo "Use MDK PackInstaller to run schema validation for $1"
   fi
 }
 
@@ -93,8 +98,8 @@ function check_pack {
   "${UTILITY_PACKCHK}" "$1" -i "${CMSIS_PACK_ROOT}/.Web/ARM.CMSIS.pdsc" -n PackName.txt
   local errorlevel=$?
   if [ $errorlevel -ne 0 ]; then
-    echo "build aborted: pack check failed"
-    echo " "
+    echo "build aborted: pack check failed" >&2
+    echo " " >&2
     exit 1
   fi
 }

--- a/lib/utilities
+++ b/lib/utilities
@@ -61,11 +61,9 @@ function find_packchk {
     report_utility "PackChk" "$UTILITY_PACKCHK"
     return 0
   fi
-
   
   echo "Error: No packchk utility found" >&2
   echo "Action: Add packchk to your path" >&2
-  
   echo "Hint: Included in CMSIS Pack:"
   echo '${CMSIS_PACK_ROOT}/ARM/CMSIS/<version>/CMSIS/Utilities/<os>/'
   echo " "

--- a/test/tests_gen_pack.sh
+++ b/test/tests_gen_pack.sh
@@ -156,11 +156,15 @@ EOF
   UTILITY_CURL="curl_mock"
   UTILITY_CURL_RESULT=6
   UTILITY_XMLLINT="xmllint_mock"
+    
+  result=$(check_schema test.pdsc 2>&1)
+  errorlevel=$?
   
-  check_schema test.pdsc
+  echo "$result"
   
-  assertContains "${CURL_MOCK_ARGS[@]}" "PACK.xsd"
-  assertNotContains "${XMLLINT_MOCK_ARGS[@]:-empty}" "test.pdsc"
+  assertNotEquals 0 $errorlevel
+  assertContains "${result}" "Failed downloading schema from 'PACK.xsd'"
+  assertNotContains "${result}" "xmllint_mock"
 }
 
 packchk_mock() {


### PR DESCRIPTION
Handle error if the pdsc file under check doesn't list a
valid schema URL, i.e. the download fails. In this case
the schema check is skipped without causing an error.