### PR TITLE
Enhance log output with more verbose messages:

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,15 @@ The following tools need to be installed on Windows machines.
 
 #### xmllint
 
-[xmllint](http://xmlsoft.org/xmllint.html) can be installed using the
+xmllint is provided by the [Chocolatey](https://chocolatey.org/install) [xsltproc package](https://chocolatey.org/packages/xsltproc).
+Installing choco and xsltproc can be done from an administrative PowerShell prompt:
+
+```ps
+> Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))
+> choco install xsltproc
+```
+
+Alternatively, [xmllint](http://xmlsoft.org/xmllint.html) can be installed manually using the
 [libxml library](https://www.zlatkovic.com/pub/libxml/). Download the following ZIP files:
 
 - iconv-1.9.2.win32.zip
@@ -70,12 +78,6 @@ The following tools need to be installed on Windows machines.
 
 Extract the /bin directory of each ZIP file to a directory, for example C:\xmllint and add this directory to the
 Windows PATH environment variable.
-
-Alternatively, xmllint is also provided by the [Chocolatey xsltproc package](https://chocolatey.org/packages/xsltproc):
-
-```ps
-> choco install xsltproc
-```
 
 #### 7-Zip
 

--- a/gen-pack
+++ b/gen-pack
@@ -7,7 +7,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-GEN_PACK_LIB_VERSION="0.8.3"
+GEN_PACK_LIB_VERSION="0.8.4"
 GEN_PACK_LIB_SOURCE="$(realpath $(dirname ${BASH_SOURCE}))"
 
 shopt -s expand_aliases
@@ -67,35 +67,9 @@ echo "Loading gen-pack library ${GEN_PACK_LIB_VERSION} from ${GEN_PACK_LIB_SOURC
 . "${GEN_PACK_LIB_SOURCE}/lib/pdsc"
 . "${GEN_PACK_LIB_SOURCE}/lib/gittools"
 . "${GEN_PACK_LIB_SOURCE}/lib/logging"
-
-# Sanity check locale setting (LANG)
-function check_locale {
-  local UTF8="\\.(UTF|utf)(-)?8$"
-  if [[ "${LANG}" =~ $UTF8 ]]; then
-    echo_v "Found LANG=${LANG} set to UTF-8 locale."
-  else
-    if [ -z "${LANG}" ]; then
-      echo_err "LANG is not set!"
-    else
-      echo_err "LANG is set to non-UTF locale '${LANG}'!"
-    fi
-    echo_log "gen-pack needs UTF-8 environment to work."
-    echo_log "Consider setting LANG to your locale!"
-    exit 1
-  fi
-}
+. "${GEN_PACK_LIB_SOURCE}/lib/helper"
 
 check_locale
-
-# Sanity check settings
-function check_placeholder {
-  local re=".*<.*>.*"
-  if [[ "${!1}" =~ $re ]]; then
-    echo_err "Variable '$1' contains placeholder '<..>'"
-    echo_log "Remove placeholders from gen-pack settings!"
-    exit 1
-  fi
-}
 
 check_placeholder "PACK_DIRS"
 check_placeholder "PACK_BASE_FILES"
@@ -207,6 +181,11 @@ function apply_patches {
 #  <pdsc>   The pack description to check
 #
 function check_schema {
+  if [ -z "${UTILITY_XMLLINT}" ]; then
+    echo_err "Cannot run schema check when missing xmllint utility!"
+    return 1
+  fi
+
   echo_log "Running schema check for $1"
   local CMSISSCHEMA=$(realpath -m "${CMSIS_TOOLSDIR:-.}/../PACK.xsd")
   local SCHEMA="${CMSISSCHEMA}"

--- a/lib/helper
+++ b/lib/helper
@@ -1,0 +1,57 @@
+#
+# Open-CMSIS-Pack gen-pack Bash library
+#
+# Copyright (c) 2022-2023 Arm Limited. All rights reserved.
+#
+# Provided as-is without warranty under Apache 2.0 License
+# SPDX-License-Identifier: Apache-2.0
+#
+
+#
+# Sanity check locale setting (LANG)
+# 
+# Usage: check_locale
+#
+function check_locale {
+  local UTF8="\\.(UTF|utf)(-)?8$"
+  if [[ "${LANG}" =~ $UTF8 ]]; then
+    echo_v "Found LANG=${LANG} set to UTF-8 locale."
+    return 0
+  fi
+  
+  if [ -z "${LANG}" ]; then
+    echo_err "LANG is not set!"
+  else
+    echo_err "LANG is set to non-UTF locale '${LANG}'!"
+  fi
+  echo_log "gen-pack needs UTF-8 environment to work."
+  echo_log "Consider setting LANG to your locale!"
+  case $(uname -s) in
+    'WindowsNT'|MINGW*|CYGWIN*)
+      echo_log 'E.g., export LANG=$(locale -s -U)'
+      export LANG=$(locale -s -U 2>/dev/null || echo "en_US.UTF-8")
+      ;;
+    *)
+      echo_log "E.g., export LANG=en_US.UTF-8"
+      export LANG=en_US.UTF-8
+      ;;
+  esac
+  echo_log "Going on with LANG=${LANG} ..."
+
+  return 1
+}
+
+#
+# Sanity check settings
+#
+# Usage: check_placeholder <var>
+#  <var>   The Bash variable name to check for placeholders  
+#
+function check_placeholder {
+  local re=".*<.*>.*"
+  if [[ "${!1}" =~ $re ]]; then
+    echo_err "Variable '$1' contains placeholder '<..>'"
+    echo_log "Remove placeholders from gen-pack settings!"
+    exit 1
+  fi
+}

--- a/lib/utilities
+++ b/lib/utilities
@@ -17,8 +17,13 @@
 #
 function report_utility {
   if [[ -n "$3" && $3 != 0 ]]; then
-    echo_err "Error: No $1 utility found"
-    echo_log "Action: Add $1 to your path"
+    if [ -n "$4" ]; then
+      echo_err "Error: No $1 utility found with version $4"
+      echo_log "Action: Add $1 version $4 to your PATH"
+    else
+      echo_err "Error: No $1 utility found"
+      echo_log "Action: Add $1 to your PATH"
+    fi
     echo_log " "
     exit $3
   else
@@ -95,7 +100,7 @@ function find_pack_root {
     local OS=$(uname -s)
     case $OS in
       'Linux'|'Darwin')
-        local DEFAULT_CMSIS_PACK_ROOT="${HOME}/.arm/Packs"
+        local DEFAULT_CMSIS_PACK_ROOT="${HOME}/.cache/arm/packs"
         ;;
       'WindowsNT'|MINGW*|CYGWIN*)
         local DEFAULT_CMSIS_PACK_ROOT="${LOCALAPPDATA//\\//}/Arm/Packs"
@@ -185,8 +190,22 @@ function find_xmllint {
 
   echo_err "Error: No xmllint utility found"
   echo_log "Action: Add xmllint to your path"
+  case $(uname -s) in
+    'WindowsNT'|MINGW*|CYGWIN*)
+      echo_log 'Try installing Chocolatey and run choco install xsltproc.'
+      echo_log 'See documentation for more details.'
+      ;;
+    'Linux')
+      if which apt-get; then
+        echo_log "Try running sudo apt-get install libxml2-utils."
+      fi
+      ;;
+    'Darwin')
+      echo_log "Try running brew install libxml2"
+      ;;
+  esac
   echo_log " "
-  exit 1
+  return 1
 }
 
 #
@@ -278,7 +297,7 @@ function find_linkchecker {
 #
 function find_doxygen {
   UTILITY_DOXYGEN=$(find_utility doxygen "-v | cut -d' ' -f1" "$1")
-  report_utility "doxygen" "$UTILITY_DOXYGEN" $?
+  report_utility "doxygen" "$UTILITY_DOXYGEN" $? "$1"
 }
 
 #

--- a/test/tests_gen_pack.sh
+++ b/test/tests_gen_pack.sh
@@ -196,6 +196,15 @@ EOF
   assertContains "${XMLLINT_MOCK_ARGS[@]}" "test.pdsc"
 }
 
+test_check_schema_no_xmllint() {
+  UTILITY_XMLLINT=""
+
+  output=$(check_schema test.pdsc 2>&1)
+
+  assertFalse $?
+  assertContains "${output}" "Cannot run schema check when missing xmllint utility!"
+}
+
 test_check_schema_nourl_version() {
   cat > test.pdsc <<EOF
 <?xml version="1.0" encoding="UTF-8"?>
@@ -351,39 +360,5 @@ test_create_sha1() {
   assertNotContains "$(cat "${PACK_BUILD}/ARM.GenPack.sha1")" "./input2"
   assertNotContains "$(cat "${PACK_BUILD}/ARM.GenPack.sha1")" "./input3"
 }
-
-test_check_locale() {
-  OLD_LANG="${LANG}"
-  export LANG="en_US.UTF-8"
-
-  output=$(check_locale 2>&1)
-  assertTrue $?
-  assertContains "${output}" "Found LANG=${LANG} set to UTF-8 locale."
-
-  export LANG="${OLD_LANG}"
-}
-
-test_check_locale_unset() {
-  OLD_LANG="${LANG}"
-  unset LANG
-
-  output=$(check_locale 2>&1)
-  assertFalse $?
-  assertContains "${output}" "LANG is not set!"
-
-  export LANG="${OLD_LANG}"
-}
-
-test_check_locale_utf8() {
-  OLD_LANG="${LANG}"
-  export LANG="POSIX"
-
-  output=$(check_locale 2>&1)
-  assertFalse $?
-  assertContains "${output}" "non-UTF locale"
-
-  export LANG="${OLD_LANG}"
-}
-
 
 . "$(dirname "$0")/shunit2/shunit2"

--- a/test/tests_helper.sh
+++ b/test/tests_helper.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+#
+# Open-CMSIS-Pack gen-pack Bash library
+#
+# Copyright (c) 2022-2023 Arm Limited. All rights reserved.
+#
+# Provided as-is without warranty under Apache 2.0 License
+# SPDX-License-Identifier: Apache-2.0
+#
+
+. "$(dirname "$0")/../lib/logging"
+. "$(dirname "$0")/../lib/helper"
+
+setUp() {
+  VERBOSE=1
+}
+
+tearDown() {
+  unset VERBOSE
+}
+
+test_check_locale() {
+  OLD_LANG="${LANG}"
+  export LANG="en_US.UTF-8"
+
+  output=$(check_locale 2>&1)
+  assertTrue $?
+  assertContains "${output}" "Found LANG=${LANG} set to UTF-8 locale."
+
+  export LANG="${OLD_LANG}"
+}
+
+test_check_locale_unset() {
+  OLD_LANG="${LANG}"
+  unset LANG
+
+  output=$(check_locale 2>&1)
+  assertFalse $?7
+  assertContains "${output}" "LANG is not set!"
+  assertContains "${output}" "Going on with LANG=$(locale -s -U 2>/dev/null || echo "en_US.UTF-8") ..."
+
+  export LANG="${OLD_LANG}"
+}
+
+test_check_locale_utf8() {
+  OLD_LANG="${LANG}"
+  export LANG="POSIX"
+
+  output=$(check_locale 2>&1)
+  assertFalse $?
+  assertContains "${output}" "non-UTF locale"
+  assertContains "${output}" "Going on with LANG=$(locale -s -U 2>/dev/null || echo "en_US.UTF-8") ..."
+
+  export LANG="${OLD_LANG}"
+}
+
+test_check_placeholder() {
+  VAR_WITHOUT_PLACEHOLDER="some\ncontent\nmore content"
+  VAR_WITH_PLACEHOLDER="some\ncontent\n<placeholder>\nmore content"
+
+  output=$(check_placeholder "VAR_WITHOUT_PLACEHOLDER" 2>&1)
+  assertTrue $?
+  assertEquals "" "${output}"
+
+  output=$(check_placeholder "VAR_WITH_PLACEHOLDER" 2>&1)
+  assertFalse $?
+  assertContains "${output}" "Variable 'VAR_WITH_PLACEHOLDER' contains placeholder"
+  assertContains "${output}" "Remove placeholders from gen-pack settings!"
+}
+
+. "$(dirname "$0")/shunit2/shunit2"

--- a/test/tests_utilities.sh
+++ b/test/tests_utilities.sh
@@ -123,7 +123,7 @@ test_find_pack_root_by_env() {
 test_find_pack_root_by_default() {
   case $(uname -s) in
     'Linux'|'Darwin')
-      local DEFAULT_CMSIS_PACK_ROOT="${HOME}/.arm/Packs"
+      local DEFAULT_CMSIS_PACK_ROOT="${HOME}/.cache/arm/packs"
       ;;
     'WindowsNT'|MINGW*|CYGWIN*)
       local DEFAULT_CMSIS_PACK_ROOT="${LOCALAPPDATA//\\//}/Arm/Packs"
@@ -545,6 +545,32 @@ EOF
 
   find_doxygen "1.8.6"
   find_doxygen "1.9.2"
+}
+
+test_find_doxygen_version() {
+  mkdir "doxygen-1.8.6"
+  mkdir "doxygen-1.9.2"
+
+  cat > "doxygen-1.8.6/doxygen" <<EOF
+#!/bin/sh
+echo "1.8.6"
+EOF
+
+  cat > "doxygen-1.9.2/doxygen" <<EOF
+#!/bin/sh
+echo "1.9.2 (caa4e3de211fbbef2c3adf58a6bd4c86d0eb7cb8)"
+EOF
+  chmod +x "doxygen-1.8.6/doxygen"
+  chmod +x "doxygen-1.9.2/doxygen"
+
+
+  remove_from_path "doxygen"
+  PATH="$(pwd)/doxygen-1.8.6:$(pwd)/doxygen-1.9.2:$PATH"
+
+  OUTPUT=$(find_doxygen "1.9.6" 2>&1)
+  assertFalse $?
+  assertContains "$OUTPUT" "Error: No doxygen utility found with version 1.9.6"
+  assertContains "$OUTPUT" "Action: Add doxygen version 1.9.6 to your PATH" 
 }
 
 . "$(dirname "$0")/shunit2/shunit2"


### PR DESCRIPTION
- Skip schema check when xmllint is missing.
- Give hints on how to install xmllint.
- Fix missing LANG setting with default (en_US.UTF-8).
- Give hints on how to permanently fix LANG environment.