### PR TITLE
Verify patch file for LF line endings

### DIFF
--- a/gen-pack
+++ b/gen-pack
@@ -7,7 +7,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-GEN_PACK_LIB_VERSION="0.8.5"
+GEN_PACK_LIB_VERSION="0.8.6"
 GEN_PACK_LIB_SOURCE="$(realpath "$(dirname "${BASH_SOURCE[0]}")")"
 
 shopt -s expand_aliases
@@ -145,6 +145,25 @@ function apply_patches {
     cwd=$(pwd)
     pushd "$1" > /dev/null || exit
     for f in ${PACK_PATCH_FILES}; do
+      local lineendings
+      lineendings=$(head -1 "${cwd}/${f}" | cat -vet | sed -E 's/^[^^$]*//' | sed -E 's/\$/LF/' | sed -E 's/.*\^M/CR/')
+      if [[ "${lineendings}" != "LF" ]]; then
+        echo_log "Patch file ${f} has ${lineendings} line terminators but should have LF only."
+        case ${lineendings} in
+          CRLF)
+            echo_log "  Converting with dos2unix..."
+            dos2unix -q "${cwd}/${f}"
+          ;;
+          CR)
+            echo_log "  Converting with mac2unix..."
+            mac2unix -q "${cwd}/${f}"
+          ;;  
+          *)
+            echo_err "  No implicit conversion rule avilable!"
+            return 1
+          ;;
+        esac
+      fi
       patch -p0 -t -i "${cwd}/${f}"
     done
     popd > /dev/null || exit

--- a/test/tests_gen_pack.sh
+++ b/test/tests_gen_pack.sh
@@ -163,8 +163,56 @@ EOF
   "
   apply_patches "${PACK_BUILD}"
 
-  assertEquals "$(cat "${PACK_BUILD}/input1/file11.txt")" "File 11 extended version"
-  assertEquals "$(cat "${PACK_BUILD}/input1/file12.txt")" "File 12"
+  assertEquals "File 11 extended version" "$(cat "${PACK_BUILD}/input1/file11.txt")"
+  assertEquals "File 12" "$(cat "${PACK_BUILD}/input1/file12.txt")"
+}
+
+test_apply_patches_crlf() {
+  createTestData
+
+  cp -r --parents "input1" "${PACK_BUILD}"
+
+  cat > file11.patch <<EOF
+--- input1/file11.txt
++++ input1/file11.txt
+@@ -1 +1 @@
+-File 11
++File 11 extended version
+EOF
+
+  unix2dos file11.patch
+
+  PACK_PATCH_FILES="
+    file11.patch
+  "
+  apply_patches "${PACK_BUILD}"
+
+  assertEquals "File 11 extended version" "$(cat "${PACK_BUILD}/input1/file11.txt")"
+  assertEquals "File 12" "$(cat "${PACK_BUILD}/input1/file12.txt")"
+}
+
+test_apply_patches_cr() {
+  createTestData
+
+  cp -r --parents "input1" "${PACK_BUILD}"
+
+  cat > file11.patch <<EOF
+--- input1/file11.txt
++++ input1/file11.txt
+@@ -1 +1 @@
+-File 11
++File 11 extended version
+EOF
+
+  unix2mac file11.patch
+
+  PACK_PATCH_FILES="
+    file11.patch
+  "
+  apply_patches "${PACK_BUILD}"
+
+  assertEquals "File 11 extended version" "$(cat "${PACK_BUILD}/input1/file11.txt")"
+  assertEquals "File 12" "$(cat "${PACK_BUILD}/input1/file12.txt")"
 }
 
 curl_mock() {


### PR DESCRIPTION
- Warn about .patch files with unsupported line endings
- Try auto-conversion of Windows/Mac line endings to Unix

Fixes #44 