### PR TITLE
Fix PACK schema retrival

### DIFF
--- a/gen-pack
+++ b/gen-pack
@@ -7,7 +7,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-GEN_PACK_LIB_VERSION="0.8.7"
+GEN_PACK_LIB_VERSION="0.8.8"
 GEN_PACK_LIB_SOURCE="$(realpath "$(dirname "${BASH_SOURCE[0]}")")"
 GEN_PACK_SCRIPT_SOURCE="$(dirname "$(readlink -f "$0")")"
 
@@ -191,33 +191,46 @@ function check_schema {
   local SCHEMA="${CMSISSCHEMA}"
   if [ ! -f "$SCHEMA" ]; then
     echo_log "Fetching schema file..."
+
     local SCHEMAURL
-    SCHEMAURL=$(grep -Pio "xs:noNamespaceSchemaLocation=\"\K[^\"]+" "$1")
+    SCHEMAURL=$(grep -Pio "noNamespaceSchemaLocation=\"\K[^\"]+" "$1")
+    if [ -z "${SCHEMAURL}" ]; then
+      echo_err "PDSC file is missing schema url. Consider adding attribute 'noNamespaceSchemaLocation' to '<package>' tag."
+    fi
+
     local SCHEMAVERSION
     SCHEMAVERSION=$(grep -Pio "schemaVersion=\"\K[^\"]+" "$1")
+    if [ -z "${SCHEMAVERSION}" ]; then
+      echo_err "PDSC file is missing schema version. Consider adding attribute 'schemaVersion' to '<package>' tag."
+    fi
+
     local SCHEMA="${TEMP:-/tmp}/PACK.xsd"
-    curl_download "${SCHEMAURL}" "${SCHEMA}"
-    local errorlevel=$?
-    if [ $errorlevel -ne 0 ]; then
-        echo_err "Schema referenced in PDSC file not found. Looking for schema with version '${SCHEMAVERSION}' ..."
-        curl_download "https://github.com/Open-CMSIS-Pack/Open-CMSIS-Pack-Spec/blob/v${SCHEMAVERSION}/schema/PACK.xsd" "${SCHEMA}"
-        errorlevel=$?
+
+    local errorlevel=1
+    if [ -n "${SCHEMAURL}" ]; then
+      curl_download "${SCHEMAURL}" "${SCHEMA}"
+      errorlevel=$?  
+    fi
+    if [ -n "${SCHEMAVERSION}" ] && [ $errorlevel -ne 0 ]; then
+      echo_err "Schema referenced in PDSC file not found. Looking for schema with version '${SCHEMAVERSION}' ..."
+      curl_download "https://raw.githubusercontent.com/Open-CMSIS-Pack/Open-CMSIS-Pack-Spec/v${SCHEMAVERSION}/schema/PACK.xsd" "${SCHEMA}"
+      errorlevel=$?
     fi
     if [ $errorlevel -ne 0 ]; then
-        echo_err "Schema referenced by PDSC file's schema version not found. Looking for latest schema ..."
-        curl_download "https://github.com/Open-CMSIS-Pack/Open-CMSIS-Pack-Spec/blob/main/schema/PACK.xsd" "${SCHEMA}"
-        errorlevel=$?
+      echo_err "Schema referenced by PDSC file's schema version not found. Looking for latest schema ..."
+      curl_download "https://raw.githubusercontent.com/Open-CMSIS-Pack/Open-CMSIS-Pack-Spec/main/schema/PACK.xsd" "${SCHEMA}"
+      errorlevel=$?
     fi
     if [ $errorlevel -ne 0 ]; then
-        echo_err "build aborted: No schema file could be found!"
-        echo_log " "
-        echo_log "  Hint: Assure one of the following to get the schema check working."
-        echo_log "        - Provide PACK.XSD into '${CMSISSCHEMA}'."
-        echo_log "        - Provide schema URL in PDSC file's xs:noNamespaceSchemaLocation attribute."
-        echo_log "        - Provide schema release tag version in PDSC file's schemaVersion attribute."
-        echo_log "        Available schema releases are listed on https://github.com/Open-CMSIS-Pack/Open-CMSIS-Pack-Spec/tags."
-        echo_log " "
-        exit $errorlevel
+      echo_err "build aborted: No schema file could be found!"
+      echo_log " "
+      echo_log "  Hint: Assure one of the following to get the schema check working."
+      echo_log "        - Provide PACK.XSD into '${CMSISSCHEMA}'."
+      echo_log "        - Provide schema URL in PDSC file's xs:noNamespaceSchemaLocation attribute."
+      echo_log "        - Provide schema release tag version in PDSC file's schemaVersion attribute."
+      echo_log "        Available schema releases are listed on https://github.com/Open-CMSIS-Pack/Open-CMSIS-Pack-Spec/tags."
+      echo_log " "
+      exit $errorlevel
     fi
   fi
   echo_v "\"${UTILITY_XMLLINT}\" --noout --schema \"${SCHEMA}\" \"$1\""

--- a/test/tests_gen_pack.sh
+++ b/test/tests_gen_pack.sh
@@ -271,8 +271,8 @@ EOF
 
   assertEquals 0 $errorlevel
   assertContains "${result}" "Failed downloading file from URL 'PACK.xsd'."
-  assertContains "${result}" "curl_mock -sL https://github.com/Open-CMSIS-Pack/Open-CMSIS-Pack-Spec/blob/v1.7.7/schema/PACK.xsd"
-  assertNotContains "${result}" "Failed downloading file from URL 'https://github.com/Open-CMSIS-Pack/Open-CMSIS-Pack-Spec/blob/v1.7.7/schema/PACK.xsd'."
+  assertContains "${result}" "curl_mock -sL https://raw.githubusercontent.com/Open-CMSIS-Pack/Open-CMSIS-Pack-Spec/v1.7.7/schema/PACK.xsd"
+  assertNotContains "${result}" "Failed downloading file from URL 'https://raw.githubusercontent.com/Open-CMSIS-Pack/Open-CMSIS-Pack-Spec/v1.7.7/schema/PACK.xsd'."
   assertContains "${result}" "xmllint_mock"
 }
 
@@ -294,9 +294,9 @@ EOF
 
   assertEquals 0 $errorlevel
   assertContains "${result}" "Failed downloading file from URL 'PACK.xsd'."
-  assertContains "${result}" "Failed downloading file from URL 'https://github.com/Open-CMSIS-Pack/Open-CMSIS-Pack-Spec/blob/v1.7.7/schema/PACK.xsd'."
-  assertContains "${result}" "curl_mock -sL https://github.com/Open-CMSIS-Pack/Open-CMSIS-Pack-Spec/blob/main/schema/PACK.xsd"
-  assertNotContains "${result}" "Failed downloading file from URL 'https://github.com/Open-CMSIS-Pack/Open-CMSIS-Pack-Spec/blob/main/schema/PACK.xsd'."
+  assertContains "${result}" "Failed downloading file from URL 'https://raw.githubusercontent.com/Open-CMSIS-Pack/Open-CMSIS-Pack-Spec/v1.7.7/schema/PACK.xsd'."
+  assertContains "${result}" "curl_mock -sL https://raw.githubusercontent.com/Open-CMSIS-Pack/Open-CMSIS-Pack-Spec/main/schema/PACK.xsd"
+  assertNotContains "${result}" "Failed downloading file from URL 'https://raw.githubusercontent.com/Open-CMSIS-Pack/Open-CMSIS-Pack-Spec/main/schema/PACK.xsd'."
   assertContains "${result}" "xmllint_mock"
 }
 
@@ -318,8 +318,31 @@ EOF
 
   assertNotEquals 0 $errorlevel
   assertContains "${result}" "Failed downloading file from URL 'PACK.xsd'."
-  assertContains "${result}" "Failed downloading file from URL 'https://github.com/Open-CMSIS-Pack/Open-CMSIS-Pack-Spec/blob/v1.7.7/schema/PACK.xsd'."
-  assertContains "${result}" "Failed downloading file from URL 'https://github.com/Open-CMSIS-Pack/Open-CMSIS-Pack-Spec/blob/main/schema/PACK.xsd'."
+  assertContains "${result}" "Failed downloading file from URL 'https://raw.githubusercontent.com/Open-CMSIS-Pack/Open-CMSIS-Pack-Spec/v1.7.7/schema/PACK.xsd'."
+  assertContains "${result}" "Failed downloading file from URL 'https://raw.githubusercontent.com/Open-CMSIS-Pack/Open-CMSIS-Pack-Spec/main/schema/PACK.xsd'."
+  assertNotContains "${result}" "xmllint_mock"
+}
+
+test_check_schema_missing_attribiutes() {
+  cat > test.pdsc <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<package>
+</package>
+EOF
+
+  UTILITY_CURL="curl_mock"
+  UTILITY_CURL_RESULT=(6 6 6)
+  UTILITY_XMLLINT="xmllint_mock"
+
+  result=$(check_schema test.pdsc 2>&1)
+  errorlevel=$?
+
+  echo "$result"
+
+  assertNotEquals 0 $errorlevel
+  assertContains "${result}" "PDSC file is missing schema url. Consider adding attribute 'noNamespaceSchemaLocation' to '<package>' tag."
+  assertContains "${result}" "PDSC file is missing schema version. Consider adding attribute 'schemaVersion' to '<package>' tag."
+  assertContains "${result}" "Failed downloading file from URL 'https://raw.githubusercontent.com/Open-CMSIS-Pack/Open-CMSIS-Pack-Spec/main/schema/PACK.xsd'."
   assertNotContains "${result}" "xmllint_mock"
 }
 


### PR DESCRIPTION
- Warn about missing noNamespaceSchemaLocation attribute
- Warn about missing schemaVersion attribute
- Skip using empty schema url for download
- Use githubusercontent.com for raw file download