### PR TITLE
Fix write-protection in CMSIS_PACK_ROOT

### DIFF
--- a/gen-pack
+++ b/gen-pack
@@ -1,13 +1,13 @@
 #
 # Open-CMSIS-Pack gen-pack Bash library
 #
-# Copyright (c) 2022-2023 Arm Limited. All rights reserved.
+# Copyright (c) 2022-2024 Arm Limited. All rights reserved.
 #
 # Provided as-is without warranty under Apache 2.0 License
 # SPDX-License-Identifier: Apache-2.0
 #
 
-GEN_PACK_LIB_VERSION="0.9.1"
+GEN_PACK_LIB_VERSION="0.9.2"
 GEN_PACK_LIB_SOURCE="$(realpath "$(dirname "${BASH_SOURCE[0]}")")"
 GEN_PACK_SCRIPT_SOURCE="$(dirname "$(readlink -f "$0")")"
 
@@ -259,16 +259,39 @@ function check_pack {
    | sed -E 's/vendor="([^"]*)"[ ]*name="([^"]*)"/\1.\2.pdsc/')
   declare -a include
   local webdir="${CMSIS_PACK_ROOT}/.Web"
+  local webdir_write_protect="no"
   if [ ! -d "${webdir}" ]; then
+    if [ -d "${CMSIS_PACK_ROOT}" ]; then
+      webdir_write_protect=$(has_write_protect "${CMSIS_PACK_ROOT}")
+      if [[ "${webdir_write_protect}" == "yes" ]]; then
+        remove_write_protect "${CMSIS_PACK_ROOT}"
+      fi
+    fi 
+    echo_v "Creating ${webdir} ..."
     mkdir -p "${webdir}"
+    if [[ "${webdir_write_protect}" == "yes" ]]; then
+      set_write_protect "${CMSIS_PACK_ROOT}"
+    fi
+  else
+    webdir_write_protect=$(has_write_protect "${CMSIS_PACK_ROOT}/.Web")
+  fi
+  if [[ "${webdir_write_protect}" == "yes" ]]; then
+    remove_write_protect "${webdir}"
   fi
   for dep in ${PACKCHK_DEPS} ${dependencies}; do
-    if [ ! -f "${webdir}/${dep}" ]; then
-      curl_download "https://www.keil.com/pack/${dep}" "${webdir}/${dep}"
+    local depfile="${webdir}/${dep}"
+    if [ ! -f "${depfile}" ]; then
+      curl_download "https://www.keil.com/pack/${dep}" "${depfile}"
+      if [[ "${webdir_write_protect}" == "yes" ]]; then
+        set_write_protect "${depfile}"
+      fi
     fi
-    include+=(-i "${webdir}/${dep}")
+    include+=(-i "${depfile}")
   done
-  if [ "${UTILITY_PACKCHK_HAS_SCHEMACHECK}" -eq 0 ]; then
+  if [[ "${webdir_write_protect}" == "yes" ]]; then
+    set_write_protect "${webdir}"
+  fi
+  if [ "${UTILITY_PACKCHK_HAS_SCHEMACHECK:-1}" -eq 0 ]; then
     PACKCHK_ARGS+=(--disable-validation)
   fi
   # shellcheck disable=SC2086

--- a/lib/helper
+++ b/lib/helper
@@ -1,7 +1,7 @@
 #
 # Open-CMSIS-Pack gen-pack Bash library
 #
-# Copyright (c) 2022-2023 Arm Limited. All rights reserved.
+# Copyright (c) 2022-2024 Arm Limited. All rights reserved.
 #
 # Provided as-is without warranty under Apache 2.0 License
 # SPDX-License-Identifier: Apache-2.0
@@ -54,4 +54,87 @@ function check_placeholder {
     echo_log "Remove placeholders from gen-pack settings!"
     exit 1
   fi
+}
+
+#
+# Get filesystem permissions
+# Returns the octal representation for Unix file permissions.
+#
+# Usage get_perms <path>
+#  <path>   File or directory to get permissions for
+#
+function get_perms {
+  case $(uname -s) in
+    'WindowsNT'|MINGW*|CYGWIN*)
+      echo "777"
+      echo_log "Filesystem permissions not supported on Windows"
+    ;;
+    *)
+      stat -c "%a" "$1"
+      return $?
+    ;;
+  esac
+  return 1
+}
+
+#
+# Check a file/folder's write flag
+# Returns yes if no write permission flag is set.
+#
+# Usage has_write_protect <path>
+#  <path>   File or directory to get write permission for
+#
+function has_write_protect {
+  local perms
+  local result
+  perms="$(get_perms "$1")"
+  result=$?
+  if [ $((8#${perms} & 8#222)) -eq 0 ]; then
+    echo_v "has_write_protect $1 => yes (${perms})"
+    echo "yes"
+    return $result
+  fi
+  echo_v "has_write_protect $1 => no (${perms})"
+  echo "no"
+  return $result
+}
+
+#
+# Remove a file/folder's write flag
+#
+# Usage set_write_protect <path>
+#  <path>   File or directory to remove all write permissions for
+#
+function set_write_protect {
+  case $(uname -s) in
+    'WindowsNT'|MINGW*|CYGWIN*)
+      echo_log "set_write_protect not supported on Windows"
+    ;;
+    *)
+      echo_v "set_write_protect $1"
+      chmod a-w "$1"
+      return $?
+    ;;
+  esac
+  return 1
+}
+
+#
+# Set a file/folder's user-write flag
+#
+# Usage remove_write_protect <path>
+#  <path>   File or directory to set user-write permission for
+#
+function remove_write_protect {
+  case $(uname -s) in
+    'WindowsNT'|MINGW*|CYGWIN*)
+      echo_log "remove_write_protect not supported on Windows"
+    ;;
+    *)
+      echo_v "remove_write_protect $1"
+      chmod u+w "$1"
+      return $?
+    ;;
+  esac
+  return 1
 }

--- a/lib/patches
+++ b/lib/patches
@@ -1,7 +1,7 @@
 #
 # Open-CMSIS-Pack gen-pack Bash library
 #
-# Copyright (c) 2022-2023 Arm Limited. All rights reserved.
+# Copyright (c) 2022-2024 Arm Limited. All rights reserved.
 #
 # Provided as-is without warranty under Apache 2.0 License
 # SPDX-License-Identifier: Apache-2.0
@@ -21,10 +21,15 @@ case $(uname -s) in
     if ! which ggrep > /dev/null; then
       echo "GNU Grep is required, run brew install grep!" >&2
       exit 1
-    fi    
+    fi
+    if ! which gstat > /dev/null; then
+      echo "GNU stat is required, run brew install coreutils!" >&2
+      exit 1
+    fi
     alias "cp"="gcp"
     alias "grep"="ggrep"
     alias "realpath"="grealpath"
+    alias "stat"="gstat"
     ;;
 esac
 


### PR DESCRIPTION
The `check_pack` function downloads missing dependency pdsc files into the `CMSIS_PACK_ROOT/.Web` folder. This download fails if the `CMSIS_PACK_ROOT` has write-protection enabled as done by `cpackget` for example. This fix considers the write-permission.