### PR TITLE
Enhancing check_pack step

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,10 @@ This library is written for Bash v5 or later and uses a couple of standard
 - sed
 - sha1sum
 - test
-- xmllint
+- xmllint (optional)
+
+In addition the `packchk` utility from [CMSIS-Toolbox](https://github.com/Open-CMSIS-Pack/cmsis-toolbox)
+is required for verification.
 
 ### Linux
 
@@ -94,13 +97,17 @@ All file references are evaluated relative to the `.pdsc` files parent directory
 can use the same relative file names as within the `.pdsc` file.
 
 1. Put the [template](template/gen_pack.sh) into the root of your package source.
+
 1. **Windows only**! Run `git update-index --chmod=+x gen_pack.sh` to set the eXecute permission. Otherwise the script will not be executable in a Linux/Mac checkout by default such as running in a GitHub Action.
+
 1. Replace `<pin lib version here>` with the version of the library you want to use, e.g. `1.0.0`.
    For available versions see [Open-CMSIS-Pack/gen-pack/tags](https://github.com/Open-CMSIS-Pack/gen-pack/tags).
    Use the tag name without the prefix "v", e.g., 0.7.0
+
 1. Add any required default command line arguments to the line `DEFAULT_ARGS=()`.
    For example, add `-c [<prefix>]` here to force creating release history from Git.
    The `<prefix>` is the version prefixed used for release tags if any.
+
 1. Replace `<list directories here>` with a list of directories that shall be included in the pack.
    The directories are included recursively with all contained files. If left empty (i.e. `PACK_DIRS=""`),
    all folders next to the `.pdsc` file are copied.
@@ -108,21 +115,36 @@ can use the same relative file names as within the `.pdsc` file.
    (i.e., resulting in `<build>/path/to/folder/**/*`).
    Folder from outside the pack root (e.g., `../path/to/src`) are copied without hierarchy into the build
    folder (i.e., resulting in `<build>/src`). For customizing the layout consider the `postprocess` hook.
+
 1. Replace `<list files here>` with a list of files that shall be included in the pack.
    This can be used as an alternative to including whole directories.
    Files from subdirectories (e.g., `path/to/file`) are copied with same hierarchy
    (i.e., resulting in `<build>/path/to/file`).
    Files from outside the pack root (e.g., `../path/to/file`) are copied without hierarchy into the build
    folder (i.e., resulting in `<build>/file`). For customizing the layout consider the `postprocess` hook.
+
 1. Replace `<list files here>` with a list of files to be removed again.
    This can be used to copy whole directories and remove files afterwards.
+
 1. Replace `<list patches here>` with a list of patches that shall be applied.
+
 1. Add additional required command line arguments for packchk to the line `PACKCHK_ARGS=()`.
    For example, add `-x M353` to suppress this warning.
-1. Replace `<list pdsc files here>` with additional `.pdsc` files required to resolve references into other packs.
+
+1. Replace `<list pdsc files here>` with additional `.pdsc` files required to resolve references into other packs during `packchk`.
+
+   The following formats can be used:
+   - Plain `.pdsc` file looked up via `index.pidx`. File will be downloaded if not already in cache.
+     E.g., `ARM.CMSIS.pdsc`.
+
+   - Path to local `.pdsc` file relative to enclosing `gen_pack.sh`.
+     E.g., `./path/to/Local.Pack.pdsc`. Relative or absolute paths leaving the scripts base directory are not accepted for security reasons.
+
+   - URL to remote `.pdsc` file. File will be downloaded if not already in cache.
+     E.g., `https://url.to/Remove.Pack.pdsc`.
+
    Packs specified in the `<requirements>` section are considered automatically and do not need to be listed.
-   For example, add `ARM.CMSIS.pdsc` to include this file during packchk. The `.pdsc` files are referenced from
-   `${CMSIS_PACK_ROOT}/.Web` folder. Missing files are downloaded.
+
 1. Replace `<full|release|tag>` for `PACK_CHANGELOG_MODE` with either of these choices. It defaults to `full`. This setting
    is only effective when generating the changelog from Git history. It affects the fallback solutions
    used to retrieve the changelog text from git:
@@ -134,6 +156,7 @@ can use the same relative file names as within the `.pdsc` file.
    `tag` forces tag annotation messages to be used without any fallback.
 
    If no changelog text can be retrieved pack generation is aborted.
+
 1. Put custom commands to be executed before/after populating the pack build folder
    into the `preprocess` and `postprocess` functions. The working directory (`pwd`) for
    both functions is the base folder containing the pack description file. The first

--- a/gen-pack
+++ b/gen-pack
@@ -7,7 +7,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-GEN_PACK_LIB_VERSION="0.9.2"
+GEN_PACK_LIB_VERSION="0.10.0"
 GEN_PACK_LIB_SOURCE="$(realpath "$(dirname "${BASH_SOURCE[0]}")")"
 GEN_PACK_SCRIPT_SOURCE="$(dirname "$(readlink -f "$0")")"
 
@@ -254,49 +254,26 @@ function check_schema {
 #
 function check_pack {
   PACKCHK_DEPS="${PACKCHK_DEPS:-ARM.CMSIS.pdsc}"
-  local dependencies
-  dependencies=$(grep -Pio "<package\s+\Kvendor=\"[^\"]+\"\s+name=\"[^\"]+\"" "$1" \
-   | sed -E 's/vendor="([^"]*)"[ ]*name="([^"]*)"/\1.\2.pdsc/')
-  declare -a include
+  local dependencies include=()
+
+  mapfile -t dependencies < <( \
+    grep -Pio "<package\s+\Kvendor=\"[^\"]+\"\s+name=\"[^\"]+\"" "$1" | \
+    sed -E 's/vendor="([^"]*)"[ ]*name="([^"]*)"/\1.\2.pdsc/' \
+  )
+
+  # shellcheck disable=SC2206
+  dependencies+=(${PACKCHK_DEPS})
+
+  fetch_pdsc_files include "${dependencies[@]}"
   local webdir="${CMSIS_PACK_ROOT}/.Web"
-  local webdir_write_protect="no"
-  if [ ! -d "${webdir}" ]; then
-    if [ -d "${CMSIS_PACK_ROOT}" ]; then
-      webdir_write_protect=$(has_write_protect "${CMSIS_PACK_ROOT}")
-      if [[ "${webdir_write_protect}" == "yes" ]]; then
-        remove_write_protect "${CMSIS_PACK_ROOT}"
-      fi
-    fi 
-    echo_v "Creating ${webdir} ..."
-    mkdir -p "${webdir}"
-    if [[ "${webdir_write_protect}" == "yes" ]]; then
-      set_write_protect "${CMSIS_PACK_ROOT}"
-    fi
-  else
-    webdir_write_protect=$(has_write_protect "${CMSIS_PACK_ROOT}/.Web")
-  fi
-  if [[ "${webdir_write_protect}" == "yes" ]]; then
-    remove_write_protect "${webdir}"
-  fi
-  for dep in ${PACKCHK_DEPS} ${dependencies}; do
-    local depfile="${webdir}/${dep}"
-    if [ ! -f "${depfile}" ]; then
-      curl_download "https://www.keil.com/pack/${dep}" "${depfile}"
-      if [[ "${webdir_write_protect}" == "yes" ]]; then
-        set_write_protect "${depfile}"
-      fi
-    fi
-    include+=(-i "${depfile}")
-  done
-  if [[ "${webdir_write_protect}" == "yes" ]]; then
-    set_write_protect "${webdir}"
-  fi
+
   if [ "${UTILITY_PACKCHK_HAS_SCHEMACHECK:-1}" -eq 0 ]; then
     PACKCHK_ARGS+=(--disable-validation)
   fi
+
   # shellcheck disable=SC2086
-  echo_v "\"${UTILITY_PACKCHK}\" ${include[*]} -n \"${PACK_OUTPUT}/PackName.txt\"" "${PACKCHK_ARGS[@]}" \"$1\"
-  "${UTILITY_PACKCHK}" "${include[@]}" -n "${PACK_OUTPUT}/PackName.txt" "${PACKCHK_ARGS[@]}" "$1"
+  echo_v "\"${UTILITY_PACKCHK}\" ${include[*]/#/-i } -n \"${PACK_OUTPUT}/PackName.txt\"" "${PACKCHK_ARGS[@]}" \"$1\"
+  "${UTILITY_PACKCHK}" "${include[@]/#/-i }" -n "${PACK_OUTPUT}/PackName.txt" "${PACKCHK_ARGS[@]}" "$1"
   local errorlevel=$?
   if [ $errorlevel -ne 0 ]; then
     echo_err "build aborted: pack check failed"
@@ -337,9 +314,7 @@ function gen_pack {
   find_packchk
   find_xmllint
   find_sha1sum
-  if [ -n "${UTILITY_XMLLINT}" ]; then
-    find_curl
-  fi
+  find_curl
   if [ -n "${CHANGELOG+x}" ]; then
     find_git
     case ${PACK_CHANGELOG_MODE} in

--- a/lib/helper
+++ b/lib/helper
@@ -60,7 +60,7 @@ function check_placeholder {
 # Get filesystem permissions
 # Returns the octal representation for Unix file permissions.
 #
-# Usage get_perms <path>
+# Usage: get_perms <path>
 #  <path>   File or directory to get permissions for
 #
 function get_perms {
@@ -70,8 +70,12 @@ function get_perms {
       echo_log "Filesystem permissions not supported on Windows"
     ;;
     *)
-      stat -c "%a" "$1"
-      return $?
+      if [ -e "$1" ]; then
+        stat -c "%a" "$1"
+        return $?
+      else
+        get_perms "$(dirname "$1")"
+      fi
     ;;
   esac
   return 1
@@ -81,12 +85,11 @@ function get_perms {
 # Check a file/folder's write flag
 # Returns yes if no write permission flag is set.
 #
-# Usage has_write_protect <path>
+# Usage: has_write_protect <path>
 #  <path>   File or directory to get write permission for
 #
 function has_write_protect {
-  local perms
-  local result
+  local perms result
   perms="$(get_perms "$1")"
   result=$?
   if [ $((8#${perms} & 8#222)) -eq 0 ]; then
@@ -102,7 +105,7 @@ function has_write_protect {
 #
 # Remove a file/folder's write flag
 #
-# Usage set_write_protect <path>
+# Usage: set_write_protect <path>
 #  <path>   File or directory to remove all write permissions for
 #
 function set_write_protect {
@@ -122,7 +125,7 @@ function set_write_protect {
 #
 # Set a file/folder's user-write flag
 #
-# Usage remove_write_protect <path>
+# Usage: remove_write_protect <path>
 #  <path>   File or directory to set user-write permission for
 #
 function remove_write_protect {
@@ -136,5 +139,47 @@ function remove_write_protect {
       return $?
     ;;
   esac
+  return 1
+}
+
+#
+# Check if a filename denotes a remote URL
+#
+# Usage: is_url <filename>
+#  <filename>    Name of a file or a remote http(s):// URL
+#
+function is_url {
+  local re="^http(s)?://"
+  if [[ "${1}" =~ $re ]]; then
+    return 0
+  fi
+  return 1
+}
+
+#
+# Check if a filename denotes a local file URI
+#
+# Usage: is_file_uri <filename>
+#  <filename>    Name of a file or file:// URI
+#
+function is_file_uri {
+  local re="^file://"
+  if [[ "${1}" =~ $re ]]; then
+    return 0
+  fi
+  return 1
+}
+
+#
+# Check if a filename denotes an absolute path
+#
+# Usage: is_absolute <filename>
+#  <filename>   Path or filename to check
+#
+function is_absolute {
+  local re="^/"
+  if [[ "${1}" =~ $re ]]; then
+    return 0
+  fi
   return 1
 }

--- a/lib/pdsc
+++ b/lib/pdsc
@@ -100,9 +100,7 @@ function pdsc_release_desc {
 #
 function pdsc_update_releases {
   local PREFIX=()
-  local DEV
-  local first
-  local last
+  local DEV first last
 
   DEV=$(pdsc_release_desc "$1")
   first=$(grep -n "<releases>" "$1" | cut -d: -f1)
@@ -118,4 +116,139 @@ function pdsc_update_releases {
   fi
   git_changelog "${PREFIX[@]}" -d "${DEV}" -f pdsc | sed "s/^/    /" >> "$2"
   tail -n +${last} "$1" >> "$2"
+}
+
+#
+# Assure <CMSIS_PACK_ROOT>/.Web exists
+#
+# Usage: assure_pack_webdir
+#
+function assure_pack_webdir {
+  local basedir webdir="${CMSIS_PACK_ROOT}/.Web"
+  local webdir_write_protect="no"
+  if [ ! -d "${webdir}" ]; then
+    basedir=$(dirname "${webdir}")
+    if [ -d "${basedir}" ]; then
+      webdir_write_protect=$(has_write_protect "${basedir}")
+      if [[ "${webdir_write_protect}" == "yes" ]]; then
+        remove_write_protect "${basedir}"
+      fi
+    fi 
+    echo_v "Creating ${webdir} ..."
+    mkdir -p "${webdir}"
+    if [[ "${webdir_write_protect}" == "yes" ]]; then
+      set_write_protect "${basedir}"
+      set_write_protect "${webdir}"
+    fi
+  fi
+  echo "${webdir}"
+  return 0
+}
+
+#
+# Get pdsc cache filename in .Web dir
+# 
+# Usage: pdsc_cache_file <pdsc>
+#  <pdsc>   Name of a pack description file in format <vendor>.<name>.pdsc
+#
+function pdsc_cache_file {
+  local webdir="${CMSIS_PACK_ROOT}/.Web"
+  local pdsc="${1}"
+  pdsc=$(basename "${pdsc}")
+  echo "${webdir}/${pdsc}"
+}
+
+#
+# Get URL for a given pdsc file from the index
+#
+# Usage: pdsc_url <pdsc>
+#  <pdsc>   Name of a pack description file in format <vendor>.<name>.pdsc
+#
+function pdsc_url {
+  local pdsc="${1}"
+  echo_v "Looking up URL for '${pdsc}'..."
+
+  if is_url "${pdsc}"; then
+    echo_v "Input already pointing to an URL."
+    echo "${pdsc}"
+    return 0
+  elif [[ "$(basename "${pdsc}")" != "${pdsc}" ]]; then
+    pdsc=$(realpath -m --relative-base="$(cwd)" "${pdsc}")
+    if is_absolute "${pdsc}"; then
+      echo_err "Reference to locale pdsc file outside of current tree not allowed!"
+      pdsc="$(basename "${pdsc}")"
+    else
+      echo_v "Using local pdsc file."
+      echo "file:/$(cwd)/${pdsc}"
+      return 0
+    fi
+  fi
+
+  local vendor name index url
+  local webdir="${CMSIS_PACK_ROOT}/.Web"
+  local pidx="${webdir}/index.pidx"
+  local default="https://www.keil.com/pack/${pdsc}"
+  
+  if [ ! -r "${pidx}" ]; then
+    echo_err "Pack index at '${pidx}' is not readable!"
+    echo_v "Using fallback '${default}'..."
+    echo "${default}"
+    return 0
+  fi
+
+  vendor=$(pdsc_vendor "${pdsc}")
+  name=$(pdsc_name "${pdsc}")
+  index=$(grep "vendor=\"${vendor}\"" "${pidx}" | \
+          grep "name=\"${name}\"" | \
+          grep "url=\"[^\"]*\"")
+  url=$(sed -E "s/.*url=\"([^\"]*)\".*/\1/" <<<"${index}")
+
+  if [ -z "${url}" ]; then
+    echo_log "No URL for '${pdsc}' found in pack index."
+    echo_v "Using fallback '${default}'..."
+    echo "${default}"
+    return 0
+  fi
+
+  echo_v "Resolved URL '${url%/}/${pdsc}'..."
+  echo "${url%/}/${pdsc}"
+
+  return 0
+}
+
+#
+# Fetch a list of PDSC files into the .Web folder
+#
+# Usage: fetch_pdsc_files <outvar> <pdsc> [...]
+#  <outvar>   Variable to place output array with all local pdsc files to
+#  <pdsc>     One or more names of pack description file(s) in format <vendor>.<name>.pdsc
+#
+function fetch_pdsc_files {
+  local webdir webdir_write_protect
+  local -n outvar=$1
+  shift
+  webdir=$(assure_pack_webdir)
+  webdir_write_protect=$(has_write_protect "${webdir}")
+  if [[ "${webdir_write_protect}" == "yes" ]]; then
+    remove_write_protect "${webdir}"
+  fi
+  for dep in "$@"; do
+    local depurl depfile
+    depfile="$(pdsc_cache_file "${dep}")"
+    if [ ! -f "${depfile}" ]; then
+      depurl="$(pdsc_url "${dep}")"
+      if is_url "${depurl}"; then
+        curl_download "${depurl}" "${depfile}"
+        if [[ "${webdir_write_protect}" == "yes" ]]; then
+          set_write_protect "${depfile}"
+        fi
+        outvar+=("${depfile}")
+      elif is_file_uri "${depurl}"; then
+        outvar+=("${dep}")
+      fi
+    fi
+  done
+  if [[ "${webdir_write_protect}" == "yes" ]]; then
+    set_write_protect "${webdir}"
+  fi
 }

--- a/lib/utilities
+++ b/lib/utilities
@@ -140,8 +140,7 @@ function find_packchk {
   UTILITY_PACKCHK_HAS_SCHEMACHECK=$([[ -f "${UTILITY_PACKCHK}" && $(packchk --help) == *--disable-validation* ]]; echo $?)
   report_utility "PackChk" "${UTILITY_PACKCHK}" && return 0
 
-  echo_v "Hint: Included in CMSIS Pack:"
-  echo_v "\${CMSIS_PACK_ROOT}/ARM/CMSIS/<version>/CMSIS/Utilities/<os>/"
+  echo_log "Hint: PackChk is part of CMSIS-Toolbox (https://github.com/Open-CMSIS-Pack/cmsis-toolbox)"
   echo_log " "
 
   exit 1

--- a/test/tests_helper.sh
+++ b/test/tests_helper.sh
@@ -8,10 +8,19 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+# shellcheck disable=SC2317
+
+shopt -s expand_aliases
+
+. "$(dirname "$0")/../lib/patches"
 . "$(dirname "$0")/../lib/logging"
 . "$(dirname "$0")/../lib/helper"
 
 setUp() {
+  TESTDIR="${SHUNIT_TMPDIR}/${_shunit_test_}/pack"
+  mkdir -p "${TESTDIR}"
+  pushd "${TESTDIR}" >/dev/null || exit
+
   VERBOSE=1
 }
 
@@ -55,7 +64,9 @@ test_check_locale_utf8() {
 }
 
 test_check_placeholder() {
+  # shellcheck disable=SC2034
   VAR_WITHOUT_PLACEHOLDER="some\ncontent\nmore content"
+  # shellcheck disable=SC2034
   VAR_WITH_PLACEHOLDER="some\ncontent\n<placeholder>\nmore content"
 
   output=$(check_placeholder "VAR_WITHOUT_PLACEHOLDER" 2>&1)
@@ -66,6 +77,52 @@ test_check_placeholder() {
   assertFalse $?
   assertContains "${output}" "Variable 'VAR_WITH_PLACEHOLDER' contains placeholder"
   assertContains "${output}" "Remove placeholders from gen-pack settings!"
+}
+
+test_is_url() {
+  output=$(is_url "http://url.to/file")
+  assertTrue $?
+
+  output=$(is_url "https://url.to/file")
+  assertTrue $?
+
+  output=$(is_url "file://path.to/file")
+  assertFalse $?
+
+  output=$(is_url "/path/to/file")
+  assertFalse $?
+
+  output=$(is_url "file")
+  assertFalse $?
+}
+
+test_is_file_uri() {
+  output=$(is_file_uri "file://path.to/file")
+  assertTrue $?
+
+  output=$(is_file_uri "http://url.to/file")
+  assertFalse $?
+
+  output=$(is_file_uri "/path/to/file")
+  assertFalse $?
+
+  output=$(is_file_uri "file")
+  assertFalse $?
+}
+
+test_has_write_protect() {
+  mkdir protected
+  chmod a-w protected
+
+  assertEquals "no" "$(has_write_protect ".")"
+  assertEquals "no" "$(has_write_protect "nonexistent/path/to/file")"
+
+  if get_perms "."; then
+    assertEquals "yes" "$(has_write_protect "protected")"
+    assertEquals "yes" "$(has_write_protect "protected/nonexistent/path/to/file")"
+  fi
+
+  chmod -R a+w protected
 }
 
 . "$(dirname "$0")/shunit2/shunit2"


### PR DESCRIPTION
- Accept plain pdsc fetched via index.pidx
- Accept local pdsc relative to gen_pack script
- Accept remote pdsc fetched via http(s)
- Make curl mandatory (fixes #54)
- Add packchk as dependency to README (fixes #53)
- Enhance packchk missing hint, pointing to CMSIS-Toolbox (fixes #53)