### PR TITLE
Enhance implicit eol conversion in apply_patches

### DIFF
--- a/.devcontainer/ubuntu-20.04/devcontainer.json
+++ b/.devcontainer/ubuntu-20.04/devcontainer.json
@@ -1,13 +1,14 @@
 {
   "name": "Ubuntu-20.04",
-  "build": { "dockerfile": "Dockerfile" },
+  "build": { "dockerfile": "dockerfile" },
 
   "customizations": {
     "vscode": {
       "extensions": [  
         "iliazeus.vscode-ansi",
         "mads-hartmann.bash-ide-vscode",
-        "timonwong.shellcheck"
+        "timonwong.shellcheck",
+        "ms-azuretools.vscode-docker"
       ]
     }
   }

--- a/.devcontainer/ubuntu-20.04/dockerfile
+++ b/.devcontainer/ubuntu-20.04/dockerfile
@@ -11,12 +11,23 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \
     apt-get install -y \
         curl \
+        dos2unix \
         git \
         libxml2-utils \
+        locales \
+        sudo \
         zip && \
-    apt-get autoremove -y && \
-    apt-get autoclean -y && \
+    apt-get clean autoclean && \
+    apt-get autoremove --yes && \
     rm -rf /var/lib/apt/lists/*
+
+# Generate locale
+RUN echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
+    locale-gen
+
+# removing sh and pointing /bin/sh to /bin/bash
+RUN rm /bin/sh && \
+    ln -s /bin/bash /bin/sh
 
 # Install GitHub CLI
 
@@ -39,14 +50,15 @@ RUN curl -LO https://github.com/Open-CMSIS-Pack/cmsis-toolbox/releases/download/
 
 ENV PATH=$PATH:/opt/cmsis-toolbox/bin
 
-# Create runner user
+# Create user
 
-RUN groupadd ${USERNAME} && \
-    useradd -m -s /bin/bash -g ${USERNAME} ${USERNAME}
+RUN groupadd --gid 1000 ${USERNAME} \
+    && useradd --uid 1000 --gid 1000 -m ${USERNAME} -s /bin/bash \
+    && echo ${USERNAME} ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/${USERNAME} \
+    && chmod 0440 /etc/sudoers.d/${USERNAME}
 
 USER ${USERNAME}
-
-WORKDIR /home/runner
+WORKDIR /home/${USERNAME}
 
 # Initialite CMSIS-Pack repo and add ARM.CMSIS pack
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,6 +43,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install \
+            dos2unix \
             kcov
 
       - name: Run kcov
@@ -94,6 +95,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install \
+            dos2unix \
             libxml2-utils
 
       - name: Install MacOS deps
@@ -102,6 +104,7 @@ jobs:
           brew install \
             bash \
             coreutils \
+            dos2unix \
             grep
 
       - name: Install CMSIS-Toolbox

--- a/README.md
+++ b/README.md
@@ -15,17 +15,22 @@ This library is written for Bash v5 or later and uses a couple of standard
 - cp
 - curl
 - dirname
+- dos2unix (optional)
 - echo
 - find
 - git (optional)
 - gh (optional)
 - grep
+- mac2unix (optional)
 - mkdir
 - mv
+- patch (optional)
 - realpath
 - sed
 - sha1sum
 - test
+- unix2dos (optional)
+- unix2mac (optional)
 - xmllint (optional)
 
 In addition the `packchk` utility from [CMSIS-Toolbox](https://github.com/Open-CMSIS-Pack/cmsis-toolbox)

--- a/gen-pack
+++ b/gen-pack
@@ -140,40 +140,48 @@ function delete_files {
 #  <build>   The temporary build folder, typically PACK_BUILD
 #
 function apply_patches {
-  # Apply patches
-  if [ -n "${PACK_PATCH_FILES}" ]; then
-    echo_log Applying patches to pack:
-    echo_log "${PACK_PATCH_FILES}"
-    echo_log " "
-    local cwd 
-    cwd=$(pwd)
-    pushd "$1" > /dev/null || exit
-    for f in ${PACK_PATCH_FILES}; do
-      local lineendings
-      lineendings=$(head -1 "${cwd}/${f}" | cat -vet | sed -E 's/^[^^$]*//' | sed -E 's/\$/LF/' | sed -E 's/.*\^M/CR/')
-      if [[ "${lineendings}" != "LF" ]]; then
-        echo_log "Patch file ${f} has ${lineendings} line terminators but should have LF only."
-        case ${lineendings} in
-          CRLF)
-            echo_log "  Converting with dos2unix..."
-            dos2unix -q "${cwd}/${f}"
-          ;;
-          CR)
-            echo_log "  Converting with mac2unix..."
-            mac2unix -q "${cwd}/${f}"
-          ;;  
-          *)
-            echo_err "  No implicit conversion rule avilable!"
-            return 1
-          ;;
-        esac
-      fi
-      patch -p0 -t -i "${cwd}/${f}"
-    done
-    popd > /dev/null || exit
-  else
+  if [ -z "${PACK_PATCH_FILES}" ]; then
     echo_log "PACK_PATCH_FILES is empty, no patches to be applied."
+    return
   fi
+
+  echo_log Applying patches to pack:
+  echo_log "${PACK_PATCH_FILES}"
+  echo_log " "
+  
+  local src dest
+  src="$(cwd)"
+  dest="${1:-${PACK_BUILD}}"
+  
+  pushd "${dest}" > /dev/null || exit
+  for patchfile in ${PACK_PATCH_FILES}; do
+    local patchfile="${src}/${patchfile}"
+    local targets
+    declare -A style
+
+    style["${patchfile}"]="$(detect_eol_style "${patchfile}")"
+    convert_eol "LF" "${patchfile}"
+
+    mapfile -t targets < <(                         \
+        patch --dry-run -p0 -t -i "${patchfile}"  | \
+          grep "ing file"                         | \
+          sed -E "s/.*ing file '?([^']*)'?/\1/"     \
+      )
+
+    for target in "${targets[@]}"; do
+      style["${target}"]="$(detect_eol_style "${target}")"
+      convert_eol "LF" "${target}"
+    done
+
+    patch -p0 -t -i "${patchfile}"
+
+    # Revert EOL style
+    for target in "${targets[@]}"; do
+      convert_eol "${style["${target}"]}" "${target}"
+    done
+    convert_eol "${style["${patchfile}"]}" "${patchfile}"
+  done
+  popd > /dev/null || exit
 }
 
 #

--- a/lib/helper
+++ b/lib/helper
@@ -183,3 +183,49 @@ function is_absolute {
   fi
   return 1
 }
+
+#
+# Detect the end of line style used in a file
+#
+# Usage: detect_eol_style <file>
+#  <file>   File to analyze
+#
+function detect_eol_style {
+  local file="$1"
+  file="$(realpath "${file}")"
+  if [ ! -r "${file}" ]; then
+    echo_err "File '${file}' does not exist!"
+    return 1
+  fi
+
+  eol=$(head -1 "${file}"                    | \
+          cat -vet                           | \
+          sed -E 's/\^[^M]//'                | \
+          sed -E 's/[^^$]*((\^.|\$)*).*/\1/' | \
+          sed -E 's/\^M/CR/'                 | \
+          sed -E 's/\$/LF/'
+        )
+  
+  echo "${eol:-LF}"
+}
+
+#
+# Convert the end of line style 
+#
+# Usage: convert_eol <to> <file> [<file>...]
+#  <to>     End of line style
+#  <file>   One or more files to convert
+#
+function convert_eol {
+  local from to=$1
+  shift
+  for f in "$@"; do
+    from=$(detect_eol_style "$f")
+    local convert="${UTILITY_EOL_CONVERTER["${from}-to-${to}"]}" 
+    if [ -x "${convert}" ]; then
+      echo_v "$("${convert}" "$f" 2>&1)"
+    elif [[ "${from}" != "${to}" ]]; then
+      echo_log "No eol converter for ${from}-to-${to}"
+    fi
+  done
+}

--- a/lib/patches
+++ b/lib/patches
@@ -26,10 +26,10 @@ case $(uname -s) in
       echo "GNU stat is required, run brew install coreutils!" >&2
       exit 1
     fi
-    alias "cp"="gcp"
+        alias "cp"="gcp"
     alias "grep"="ggrep"
     alias "realpath"="grealpath"
-    alias "stat"="gstat"
+        alias "stat"="gstat"
     ;;
 esac
 

--- a/lib/utilities
+++ b/lib/utilities
@@ -62,13 +62,13 @@ function find_utility {
       local VERSION
       VERSION=$(bash -c "'${executable}' ${2}")
       if [[ "$VERSION" == "$3" ]]; then
-        realpath -q "${executable}"
+        realpath -s -q "${executable}"
         return $?
       fi
     done
     return 1
   fi
-  realpath -q "${UTILS[0]}"
+  realpath -s -q "${UTILS[0]}"
   return $?
 }
 
@@ -265,6 +265,41 @@ function find_linkchecker {
 function find_doxygen {
   UTILITY_DOXYGEN=$(find_utility doxygen "-v | cut -d' ' -f1" "$1")
   report_utility "doxygen" "$UTILITY_DOXYGEN" $? "$1" && return
+}
+
+#
+# Find end-of-line converters
+#
+function find_eol_converter {
+  declare -g -A UTILITY_EOL_CONVERTER=()
+
+  UTILITY_EOL_CONVERTER['CRLF-to-LF']=$(find_utility dos2unix)
+  report_utility "dos2unix" "${UTILITY_EOL_CONVERTER['CRLF-to-LF']}" $?
+  local result=$?
+
+  UTILITY_EOL_CONVERTER['LF-to-CRLF']=$(find_utility unix2dos)
+  report_utility "unix2dos" "${UTILITY_EOL_CONVERTER['LF-to-CRLF']}" $?
+  ((result+=$?))
+
+  if [[ $result != 0 ]] ; then
+    echo_err "Warning: File conversion for files using Windows line endings may cause issues"
+    echo_log "Action: Install dos2unix/unix2dos converter"
+    echo_log ""
+  fi
+
+  UTILITY_EOL_CONVERTER['CR-to-LF']=$(find_utility mac2unix)
+  report_utility "mac2unix" "${UTILITY_EOL_CONVERTER['CR-to-LF']}" $?
+  result=$?
+
+  UTILITY_EOL_CONVERTER['LF-to-CR']=$(find_utility unix2mac)
+  report_utility "unix2mac" "${UTILITY_EOL_CONVERTER['LF-to-CR']}" $?
+  ((result+=$?))
+
+  if [[ $result != 0 ]] ; then
+    echo_err "Warning: File conversion for files using classic Mac line endings may cause issues"
+    echo_log "Action: Install mac2unix/unix2mac converter"
+    echo_log ""
+  fi
 }
 
 #

--- a/test/tests_gen_pack.sh
+++ b/test/tests_gen_pack.sh
@@ -170,6 +170,10 @@ EOF
 }
 
 test_apply_patches_crlf() {
+  declare -g -A UTILITY_EOL_CONVERTER=()
+  UTILITY_EOL_CONVERTER["CRLF-to-LF"]="$(which dos2unix)"
+  UTILITY_EOL_CONVERTER["LF-to-CRLF"]="$(which unix2dos)"
+
   createTestData
 
   cp -r --parents "input1" "${PACK_BUILD}"
@@ -183,17 +187,29 @@ test_apply_patches_crlf() {
 EOF
 
   unix2dos file11.patch
+  unix2dos "${PACK_BUILD}/input1/file11.txt"
 
   PACK_PATCH_FILES="
     file11.patch
   "
+
   apply_patches "${PACK_BUILD}"
+
+  assertEquals "CRLF" "$(detect_eol_style "${PACK_BUILD}/input1/file11.txt")"
+
+  dos2unix "${PACK_BUILD}/input1/file11.txt"
 
   assertEquals "File 11 extended version" "$(cat "${PACK_BUILD}/input1/file11.txt")"
   assertEquals "File 12" "$(cat "${PACK_BUILD}/input1/file12.txt")"
+  
+  unset UTILITY_EOL_CONVERTER
 }
 
 test_apply_patches_cr() {
+  declare -g -A UTILITY_EOL_CONVERTER=()
+  UTILITY_EOL_CONVERTER["CR-to-LF"]="$(which mac2unix)"
+  UTILITY_EOL_CONVERTER["LF-to-CR"]="$(which unix2mac)"
+
   createTestData
 
   cp -r --parents "input1" "${PACK_BUILD}"
@@ -207,14 +223,22 @@ test_apply_patches_cr() {
 EOF
 
   unix2mac file11.patch
+  unix2mac "${PACK_BUILD}/input1/file11.txt"
 
   PACK_PATCH_FILES="
     file11.patch
   "
+
   apply_patches "${PACK_BUILD}"
+
+  assertEquals "CR" "$(detect_eol_style "${PACK_BUILD}/input1/file11.txt")"
+
+  mac2unix "${PACK_BUILD}/input1/file11.txt"
 
   assertEquals "File 11 extended version" "$(cat "${PACK_BUILD}/input1/file11.txt")"
   assertEquals "File 12" "$(cat "${PACK_BUILD}/input1/file12.txt")"
+
+  unset UTILITY_EOL_CONVERTER
 }
 
 curl_mock() {

--- a/test/tests_integ.sh
+++ b/test/tests_integ.sh
@@ -13,21 +13,25 @@
 DIRNAME="$(realpath "$(dirname "$0")")"
 
 setUp() {
+  # shellcheck disable=SC2155
   export GEN_PACK_LIB="$(realpath "${DIRNAME}/../")"
   TESTDIR="${SHUNIT_TMPDIR}/${_shunit_test_}"
   mkdir -p "${TESTDIR}"
-  pushd "${TESTDIR}" >/dev/null
+  pushd "${TESTDIR}" >/dev/null || exit
+ 
+  export GIT_COMMITTER_NAME="github-actions"
+  export GIT_COMMITTER_EMAIL="github-actions@github.com"
 }
 
 teardown() {
   unset GEN_PACK_LIB
   unset TESTDIR
-  popd >/dev/null
+  popd >/dev/null || exit
 }
 
 test_integ_default() {
   cp -r "${DIRNAME}/test_integ_default" .
-  cd test_integ_default
+  cd test_integ_default || return
 
   rm -rf build output
 
@@ -55,10 +59,10 @@ test_integ_default() {
 test_integ_with_git_release() {
   mkdir -p test_integ_with_git
   tar -xjf "${DIRNAME}/test_integ_with_git.tbz2" -C test_integ_with_git
-  cd test_integ_with_git
+  cd test_integ_with_git || return
 
-  git --git-dir=$(pwd)/.git clean -fdxq
-  git --git-dir=$(pwd)/.git checkout -fq v1.0.0
+  git --git-dir="$(pwd)/.git" clean -fdxq
+  git --git-dir="$(pwd)/.git" checkout -fq v1.0.0
 
   ./gen_pack.sh -k
 
@@ -83,15 +87,16 @@ test_integ_with_git_release() {
 test_integ_with_git_prerelease() {
   mkdir -p test_integ_with_git
   tar -xjf "${DIRNAME}/test_integ_with_git.tbz2" -C test_integ_with_git
-  cd test_integ_with_git
+  cd test_integ_with_git || return
 
-  git --git-dir=$(pwd)/.git clean -fdxq
-  git --git-dir=$(pwd)/.git checkout -fq v1.0.0
+  git --git-dir="$(pwd)/.git" config --global user.email "you@example.com"
+  git --git-dir="$(pwd)/.git" config --global user.name "Your Name"
 
-  GIT_COMMITTER_NAME="github-actions"
-  GIT_COMMITTER_EMAIL="github-actions@github.com"
-  GIT_COMMITTER_DATE="2022-08-04T16:00:00Z"
-  git --git-dir=$(pwd)/.git tag -m "Active development ..." v1.0.0-dev v1.0.0^
+  git --git-dir="$(pwd)/.git" clean -fdxq
+  git --git-dir="$(pwd)/.git" checkout -fq v1.0.0
+
+  export GIT_COMMITTER_DATE="2022-08-04T16:00:00Z"
+  git --git-dir="$(pwd)/.git" tag -m "Active development ..." v1.0.0-dev v1.0.0^
 
   ./gen_pack.sh -k
 
@@ -117,10 +122,10 @@ test_integ_with_git_prerelease() {
 test_integ_with_git_devdrop() {
   mkdir -p test_integ_with_git
   tar -xjf "${DIRNAME}/test_integ_with_git.tbz2" -C test_integ_with_git
-  cd test_integ_with_git
+  cd test_integ_with_git || exit
 
-  git --git-dir=$(pwd)/.git clean -fdxq
-  git --git-dir=$(pwd)/.git checkout -fq main
+  git --git-dir="$(pwd)/.git" clean -fdxq
+  git --git-dir="$(pwd)/.git" checkout -fq main
 
   ./gen_pack.sh -k
 
@@ -146,10 +151,10 @@ test_integ_with_git_devdrop() {
 test_integ_with_git_v2_dev() {
   mkdir -p test_integ_with_git
   tar -xjf "${DIRNAME}/test_integ_with_git.tbz2" -C test_integ_with_git
-  cd test_integ_with_git
+  cd test_integ_with_git || return
 
-  git --git-dir=$(pwd)/.git clean -fdxq
-  git --git-dir=$(pwd)/.git checkout -fq v2
+  git --git-dir="$(pwd)/.git" clean -fdxq
+  git --git-dir="$(pwd)/.git" checkout -fq v2
 
   ./gen_pack.sh -k
 

--- a/test/tests_utilities.sh
+++ b/test/tests_utilities.sh
@@ -314,7 +314,7 @@ EOF
 test_integ_archive_7zip() {
   remove_from_path "zip"
 
-  if $(find_zip 1>/dev/null 2>&1); then
+  if (find_zip 1>/dev/null 2>&1); then
     find_zip
 
     mkdir -p input
@@ -337,7 +337,7 @@ test_integ_archive_gnuzip() {
   PROGRAMFILES=""
   remove_from_path "7z"
 
-  if $(find_zip 1>/dev/null 2>&1); then
+  if (find_zip 1>/dev/null 2>&1); then
     find_zip
 
     mkdir -p input
@@ -431,15 +431,15 @@ EOF
 
   UTIL=$(find_utility "util")
   assertEquals 0 $?
-  assertEquals "$(realpath $(cwd))/util-1.0/util" "$UTIL"
+  assertEquals "$(realpath "$(cwd)")/util-1.0/util" "$UTIL"
 
   UTIL=$(find_utility "util" "-v" "1.0.0")
   assertEquals 0 $?
-  assertEquals "$(realpath $(cwd))/util-1.0/util" "$UTIL"
+  assertEquals "$(realpath "$(cwd)")/util-1.0/util" "$UTIL"
 
   UTIL=$(find_utility "util" "-v" "2.0.3")
   assertEquals 0 $?
-  assertEquals "$(realpath $(cwd))/util-2.0/util" "$UTIL"
+  assertEquals "$(realpath "$(cwd)")/util-2.0/util" "$UTIL"
 }
 
 test_find_utility_version_na() {
@@ -490,11 +490,11 @@ EOF
 
   UTIL=$(find_utility "util" "-v" "1.0.0")
   assertEquals 0 $?
-  assertEquals "$(realpath $(cwd))/util 1.0/util" "$UTIL"
+  assertEquals "$(realpath "$(cwd)")/util 1.0/util" "$UTIL"
 
   UTIL=$(find_utility "util" "-v" "2.0.3")
   assertEquals 0 $?
-  assertEquals "$(realpath $(cwd))/util 2.0/util" "$UTIL"
+  assertEquals "$(realpath "$(cwd)")/util 2.0/util" "$UTIL"
 }
 
 _test_find_() {
@@ -512,11 +512,11 @@ EOF
   remove_from_path "$1"
   PATH="$(cwd)/bin:$PATH"
 
-  find_${utility}
+  "find_${utility}"
   assertEquals 0 $?
   assertEquals "$(cwd)/bin/$1" "${!utility_var}"
 
-  OUTPUT=$(find_${utility} 2>&1 > /dev/null)
+  OUTPUT=$("find_${utility}" 2>&1 > /dev/null)
   assertNotContains "Error" "$OUTPUT"
   assertNotContains "Warning" "$OUTPUT"
   assertNotContains "Info" "$OUTPUT"
@@ -565,11 +565,11 @@ EOF
 
   find_doxygen "1.8.6"
   assertEquals 0 $?
-  assertEquals "$(realpath $(cwd))/doxygen-1.8.6/doxygen" "$UTILITY_DOXYGEN"
+  assertEquals "$(realpath "$(cwd)")/doxygen-1.8.6/doxygen" "$UTILITY_DOXYGEN"
 
   find_doxygen "1.9.2"
   assertEquals 0 $?
-  assertEquals "$(realpath $(cwd))/doxygen-1.9.2/doxygen" "$UTILITY_DOXYGEN"
+  assertEquals "$(realpath "$(cwd)")/doxygen-1.9.2/doxygen" "$UTILITY_DOXYGEN"
 }
 
 test_find_doxygen_version() {
@@ -608,6 +608,15 @@ test_find_sha1sum() {
 
 test_find_linkchecker() {
   _test_find_ linkchecker
+}
+
+test_find_eol_converter() {
+  find_eol_converter
+
+  assertContains "${!UTILITY_EOL_CONVERTER[*]}" "CRLF-to-LF"
+  assertContains "${!UTILITY_EOL_CONVERTER[*]}" "CR-to-LF"
+  assertContains "${!UTILITY_EOL_CONVERTER[*]}" "LF-to-CRLF"
+  assertContains "${!UTILITY_EOL_CONVERTER[*]}" "LF-to-CR"
 }
 
 . "$(dirname "$0")/shunit2/shunit2"


### PR DESCRIPTION
Patch files and files to be patched are now implicitly converted to Unix line endings and converted back to original style after applying the patch.
Fixes #58