### PR TITLE
Fix find_packchk schema check ability detection

### DIFF
--- a/lib/utilities
+++ b/lib/utilities
@@ -136,8 +136,8 @@ function find_pack_root {
 function find_packchk {
   CMSIS_TOOLSDIR="$(test -d "${CMSIS_PACK_ROOT}/ARM/CMSIS" && find "${CMSIS_PACK_ROOT}/ARM/CMSIS" -maxdepth 1 -type d | sort -r | head -1)/CMSIS/Utilities/$(get_os_type)"
   UTILITY_PACKCHK="$(find_utility packchk || find_utility "${CMSIS_TOOLSDIR}/packchk")"
-# shellcheck disable=SC2034
-  UTILITY_PACKCHK_HAS_SCHEMACHECK=$([[ -f "${UTILITY_PACKCHK}" && $(packchk --help) == *--disable-validation* ]]; echo $?)
+  # shellcheck disable=SC2034
+  UTILITY_PACKCHK_HAS_SCHEMACHECK=$([[ -f "${UTILITY_PACKCHK}" && $("${UTILITY_PACKCHK}" --help) == *--disable-validation* ]]; echo $?)
   report_utility "PackChk" "${UTILITY_PACKCHK}" && return 0
 
   echo_log "Hint: PackChk is part of CMSIS-Toolbox (https://github.com/Open-CMSIS-Pack/cmsis-toolbox)"

--- a/test/tests_utilities.sh
+++ b/test/tests_utilities.sh
@@ -153,7 +153,19 @@ test_find_packchk_by_env() {
 #!/usr/bin/env bash
 echo "packchk \$*"
 if [[ "\$*" =~ "--help" ]]; then
-  echo "--disable-validation"
+  cat <<EOH
+packchk 1.4.4 (C) 2012-2025 Arm Ltd. and Contributors
+
+Usage:
+  packchk [-V] [--version] [-h] [--help]
+          [OPTIONS...] <PDSC file>
+
+packchk options:
+  -V, --version               Print version
+  -h, --help                  Print usage
+      --disable-validation    Disable the pdsc validation against the PACK.xsd.
+      --pedantic              Return with error value on warning
+EOH
 fi
 EOF
   chmod +x packchk
@@ -162,6 +174,33 @@ EOF
 
   assertEquals "$(cwd)/packchk" "${UTILITY_PACKCHK}"
   assertEquals "0" "${UTILITY_PACKCHK_HAS_SCHEMACHECK}"
+}
+
+test_find_packchk_without_schemacheck() {
+  cat > packchk <<EOF
+#!/usr/bin/env bash
+echo "packchk \$*"
+if [[ "\$*" =~ "--help" ]]; then
+  cat <<EOH
+packchk 1.4.4 (C) 2012-2025 Arm Ltd. and Contributors
+
+Usage:
+  packchk [-V] [--version] [-h] [--help]
+          [OPTIONS...] <PDSC file>
+
+packchk options:
+  -V, --version               Print version
+  -h, --help                  Print usage
+      --pedantic              Return with error value on warning
+EOH
+fi
+EOF
+  chmod +x packchk
+
+  find_packchk
+
+  assertEquals "$(cwd)/packchk" "${UTILITY_PACKCHK}"
+  assertEquals "1" "${UTILITY_PACKCHK_HAS_SCHEMACHECK}"
 }
 
 test_find_packchk_by_pack() {


### PR DESCRIPTION
`find_packchk` was relying on `packchk` on the path for schema check ability detection. This would pick up from the `PATH` instead the formerly detected command. During testing, without any `packchk` on the `PATH`, this caused error messages.